### PR TITLE
Add comma to punctuation replacements ' , ' => ', '

### DIFF
--- a/schlagzeilen.py
+++ b/schlagzeilen.py
@@ -103,6 +103,7 @@ class ZwoaSchlogzeiln():
         # Punktuation bereinigen
         satzneu = satzneu.replace(' : ', ': ')
         satzneu = satzneu.replace(' . ', '. ')
+        satzneu = satzneu.replace(' , ', ', ')
         satzneu = satzneu.replace(' ?', '?')
         satzneu = satzneu.replace(' .', '.')
         satzneu = satzneu.replace(' !', '!')


### PR DESCRIPTION
Cleans up an unnecessary space before a comma like in https://twitter.com/ZwoaSchlogzeiln/status/1461688235650957319